### PR TITLE
Avoid the divide-by-zero situation by doing what's done on tip

### DIFF
--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -656,6 +656,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             // for PQ, the PQ codes are transposed, so we need to transpose them back
             if matches!(Q::quantization_type(), QuantizationType::Product) {
                 for batch in part_batches.iter_mut() {
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+
                     let codes = batch[PQ_CODE_COLUMN]
                         .as_fixed_size_list()
                         .values()


### PR DESCRIPTION
* Closes https://linear.app/rerun/issue/RR-2275/divide-by-zero-in-lance-during-domaintenance