### PR TITLE
Fix crash in `FilteredReadStream` on task cancellation

### DIFF
--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -436,7 +436,7 @@ impl FilteredReadStream {
                     SpawnedTask::spawn(
                         Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
                     )
-                    .map(|thread_result| thread_result.unwrap())
+                    .map(|thread_result| thread_result?)
                 }
             })
             .buffered(fragment_readahead);


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` with `?` in `FilteredReadStream` to propagate thread join errors instead of panicking

* Upstream PR: https://github.com/lance-format/lance/pull/6545

## Test plan
- [x] Existing tests pass — this is a pure error-handling improvement with no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)