### PR TITLE
cherry-pick: lance#6711: optimize_indices no-op on steady state

### DIFF
--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -393,6 +393,77 @@ def test_migration_via_fragment_apis(tmp_path):
     assert ds2.data_storage_version == "2.0"
 
 
+def test_optimize_indices_second_call_is_noop(tmp_path: Path):
+    """A second optimize_indices call when nothing has changed since the first
+    must not write any new files to the dataset directory."""
+    base_dir = tmp_path / "dataset"
+
+    n = 1024
+    rng = np.random.default_rng(0)
+    vectors = rng.standard_normal((n, 8)).astype(np.float32)
+    table = pa.table(
+        {
+            "id": pa.array(range(n), type=pa.int64()),
+            "category": pa.array([f"cat{i % 4}" for i in range(n)]),
+            "tags": pa.array([[f"t{i % 3}", f"t{(i + 1) % 3}"] for i in range(n)]),
+            "doc": pa.array([f"hello world document {i}" for i in range(n)]),
+            "name": pa.array([f"name_{i:05d}" for i in range(n)]),
+            "value": pa.array(range(n), type=pa.int64()),
+            "bloom_val": pa.array(range(n), type=pa.int64()),
+            "vector": pa.FixedSizeListArray.from_arrays(
+                pa.array(vectors.reshape(-1), type=pa.float32()), 8
+            ),
+        }
+    )
+    dataset = lance.write_dataset(table, base_dir)
+
+    dataset.create_scalar_index("id", index_type="BTREE")
+    dataset.create_scalar_index("category", index_type="BITMAP")
+    dataset.create_scalar_index("tags", index_type="LABEL_LIST")
+    dataset.create_scalar_index("doc", index_type="INVERTED")
+    dataset.create_scalar_index("name", index_type="NGRAM")
+    dataset.create_scalar_index("value", index_type="ZONEMAP")
+    dataset.create_scalar_index("bloom_val", index_type="BLOOMFILTER")
+    # num_partitions=1 keeps this dataset balanced: the auto-rebalance check
+    # in merge_indices only finds join candidates when num_partitions > 1, and
+    # 1024 + 128 rows is well below the split threshold. Without this, the
+    # rebalance heuristic would keep finding work on the small partitions.
+    dataset.create_index(
+        "vector", index_type="IVF_PQ", num_partitions=1, num_sub_vectors=2
+    )
+
+    extra_rows = 128
+    extra_vectors = rng.standard_normal((extra_rows, 8)).astype(np.float32)
+    extra = pa.table(
+        {
+            "id": pa.array(range(n, n + extra_rows), type=pa.int64()),
+            "category": pa.array([f"cat{i % 4}" for i in range(extra_rows)]),
+            "tags": pa.array([[f"t{i % 3}"] for i in range(extra_rows)]),
+            "doc": pa.array([f"goodbye world document {i}" for i in range(extra_rows)]),
+            "name": pa.array([f"add_{i:05d}" for i in range(extra_rows)]),
+            "value": pa.array(range(n, n + extra_rows), type=pa.int64()),
+            "bloom_val": pa.array(range(n, n + extra_rows), type=pa.int64()),
+            "vector": pa.FixedSizeListArray.from_arrays(
+                pa.array(extra_vectors.reshape(-1), type=pa.float32()), 8
+            ),
+        }
+    )
+    dataset = lance.write_dataset(extra, base_dir, mode="append")
+
+    # First optimize: should pull the new fragment into each index.
+    dataset.optimize.optimize_indices()
+
+    files_before = {p.relative_to(base_dir) for p in base_dir.rglob("*") if p.is_file()}
+
+    # Second optimize: nothing has changed, so this must be a no-op on disk.
+    dataset.optimize.optimize_indices()
+
+    files_after = {p.relative_to(base_dir) for p in base_dir.rglob("*") if p.is_file()}
+
+    new_files = files_after - files_before
+    assert not new_files, f"second optimize_indices created new files: {new_files}"
+
+
 def test_compaction_generates_rewrite_transaction(tmp_path: Path):
     # Create a small dataset with multiple fragments
     base_dir = tmp_path / "rewrite_txn"

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -849,6 +849,19 @@ impl DatasetIndexExt for Dataset {
         let mut new_indices = vec![];
         let mut removed_indices = vec![];
         for deltas in name_to_indices.values() {
+            // Scalar indices have no rebalance concept, so skip them entirely
+            // when every fragment is already covered and the caller hasn't
+            // asked for retrain or an explicit delta merge. Vector indices
+            // fall through and use a rebalance-aware no-op check inside
+            // merge_indices_with_unindexed_frags.
+            if !options.retrain
+                && options.num_indices_to_merge.is_none_or(|n| n == 0)
+                && index_group_is_scalar(self, deltas)
+                && index_group_has_no_unindexed(self, deltas)
+            {
+                continue;
+            }
+
             let Some(res) = merge_indices(dataset.clone(), deltas.as_slice(), options).await?
             else {
                 continue;
@@ -955,6 +968,32 @@ impl DatasetIndexExt for Dataset {
             ))),
         }
     }
+}
+
+fn index_group_is_scalar(dataset: &Dataset, deltas: &[&IndexMetadata]) -> bool {
+    let Some(field_id) = deltas.first().and_then(|d| d.fields.first()) else {
+        return false;
+    };
+    match dataset.schema().field_by_id(*field_id) {
+        Some(field) => !is_vector_field(field.data_type()),
+        None => false,
+    }
+}
+
+fn index_group_has_no_unindexed(dataset: &Dataset, deltas: &[&IndexMetadata]) -> bool {
+    let mut indexed = RoaringBitmap::new();
+    for idx in deltas {
+        if let Some(bitmap) = idx.fragment_bitmap.as_ref() {
+            indexed |= bitmap;
+        } else {
+            // Pre-0.8 indices have no fragment bitmap; treat as needing optimize.
+            return false;
+        }
+    }
+    dataset
+        .fragments()
+        .iter()
+        .all(|frag| indexed.contains(frag.id as u32))
 }
 
 fn sum_indexed_rows_per_delta(indexed_fragments_per_delta: &[Vec<Fragment>]) -> Result<Vec<usize>> {

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -180,6 +180,18 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
             Ok((new_uuid, 1, created_index))
         }
         it if it.is_vector() => {
+            // No-op when nothing changed: avoids rewriting an identical
+            // vector index on every optimize_indices() call. Matches the
+            // scalar gate in `Dataset::optimize_indices`; treats
+            // `OptimizeOptions::append()` (num_indices_to_merge=Some(0))
+            // as "no explicit merge requested".
+            if unindexed.is_empty()
+                && !options.retrain
+                && options.num_indices_to_merge.is_none_or(|n| n == 0)
+            {
+                return Ok(None);
+            }
+
             let new_data_stream = if unindexed.is_empty() {
                 None
             } else {
@@ -393,6 +405,102 @@ mod tests {
             num_rows += index.num_rows();
         }
         assert_eq!(num_rows, 2000);
+    }
+
+    /// Regression: a second `OptimizeOptions::append()` call on a steady-state
+    /// vector index used to fall through to `optimize_vector_indices` and write
+    /// a new UUID directory + manifest even though nothing had changed. The
+    /// no-op gate inside `merge_indices_with_unindexed_frags` should bail out
+    /// when no new data is unindexed and no merge/retrain was requested.
+    #[tokio::test]
+    async fn test_optimize_indices_append_is_noop_on_steady_state() {
+        const DIM: usize = 64;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            true,
+        )]));
+        let make_batch = || {
+            let arr = Arc::new(
+                FixedSizeListArray::try_new_from_values(
+                    generate_random_array(1000 * DIM),
+                    DIM as i32,
+                )
+                .unwrap(),
+            );
+            RecordBatch::try_new(schema.clone(), vec![arr]).unwrap()
+        };
+
+        let batches =
+            RecordBatchIterator::new(vec![make_batch()].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+
+        // num_partitions = 1 so the auto-rebalance heuristic has no join/split
+        // candidate after the initial build — keeps this test focused on the
+        // append-no-op behavior rather than the rebalance path.
+        let params = VectorIndexParams::with_ivf_pq_params(
+            MetricType::L2,
+            IvfBuildParams::new(1),
+            PQBuildParams {
+                num_sub_vectors: 2,
+                ..Default::default()
+            },
+        );
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap();
+
+        let batches =
+            RecordBatchIterator::new(vec![make_batch()].into_iter().map(Ok), schema.clone());
+        dataset.append(batches, None).await.unwrap();
+
+        // First append: folds the new fragment into a fresh delta segment.
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        let version_before = dataset.version().version;
+        let object_store = dataset.object_store.as_ref();
+        let dirs_before = object_store
+            .read_dir(dataset.indices_dir())
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+
+        // Second append: nothing changed since the previous call. Must not
+        // bump the manifest version or add a new UUID directory.
+        let mut dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        let dirs_after = object_store
+            .read_dir(dataset.indices_dir())
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(
+            dataset.version().version,
+            version_before,
+            "second optimize_indices(append()) bumped the dataset version"
+        );
+        assert_eq!(
+            dirs_after, dirs_before,
+            "second optimize_indices(append()) created a new index directory"
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Cherry-pick of upstream [lance-format/lance#6711](https://github.com/lance-format/lance/pull/6711) (commit `374d58f2`) into `release-3.0.0`. See upstream PR and [this discord thread](https://discord.com/channels/1030247538198061086/1499094312376467517) for rationale.

### Related
[RR-2364](https://linear.app/rerun/issue/RR-2364)

### Conflict

Upstream patch splits into two parts:

1. **Scalar gate** in `rust/lance/src/index.rs` — short-circuits scalar index groups when every fragment is covered. Applied cleanly.
2. **Vector gate** in `rust/lance/src/index/append.rs` — patches a vector arm that references `logical_index`, `ivf_view`, and `select_segment_for_single_rebalance`.

Part 2 conflicted on cherry-picl because those symbols come from upstream PR [#6402](https://github.com/lance-format/lance/pull/6402) (`feat: optimize one segmented vector segment per run`) which is **not in `release-3.0.0`**. Git lined the hunk up textually against our scalar arm, producing nonsensical markers.

### Resolution

- Kept our scalar arm unchanged.
- Replaced the upstream vector hunk with a simplified guard at the top of the vector arm in `merge_indices_with_unindexed_frags`:

  ```rust
  if unindexed.is_empty()
      && !options.retrain
      && options.num_indices_to_merge.is_none_or(|n| n == 0)
  {
      return Ok(None);
  }
  ```

- Dropped the `select_segment_for_single_rebalance` / `use_single_segment_rebalance` references (require #6402).
- Kept the new regression test, adjusted docstring to match.

### Why safe

- Single-segment auto-rebalance bug from upstream description **cannot occur** in our branch — the rebalance path itself doesn't exist without #6402.
- Remaining vector concern (rewriting identical UUID dir on steady state via `optimize_vector_indices`) is fully covered by the simpler guard above.
- Scalar gate matches upstream exactly.
- `OptimizeOptions::append()` semantics (`num_indices_to_merge = Some(0)`) handled identically.

