### PR TITLE
feat: use the dataset format version for indexes

### DIFF
--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -11,6 +11,7 @@ use deepsize::DeepSizeOf;
 use futures::TryStreamExt;
 use lance_core::{Error, Result, cache::LanceCache};
 use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
+use lance_encoding::version::LanceFileVersion;
 use lance_file::previous::{
     reader::FileReader as PreviousFileReader,
     writer::{FileWriter as PreviousFileWriter, ManifestProvider as PreviousManifestProvider},
@@ -37,6 +38,7 @@ pub struct LanceIndexStore {
     index_dir: Path,
     metadata_cache: Arc<LanceCache>,
     scheduler: Arc<ScanScheduler>,
+    file_version: LanceFileVersion,
 }
 
 impl DeepSizeOf for LanceIndexStore {
@@ -54,6 +56,21 @@ impl LanceIndexStore {
         index_dir: Path,
         metadata_cache: Arc<LanceCache>,
     ) -> Self {
+        Self::new_with_version(
+            object_store,
+            index_dir,
+            metadata_cache,
+            LanceFileVersion::default(),
+        )
+    }
+
+    /// Create a new index store at the given directory, using the provided format version
+    pub fn new_with_version(
+        object_store: Arc<ObjectStore>,
+        index_dir: Path,
+        metadata_cache: Arc<LanceCache>,
+        file_version: LanceFileVersion,
+    ) -> Self {
         let scheduler = ScanScheduler::new(
             object_store.clone(),
             SchedulerConfig::max_bandwidth(&object_store),
@@ -63,6 +80,7 @@ impl LanceIndexStore {
             index_dir,
             metadata_cache,
             scheduler,
+            file_version,
         }
     }
 }
@@ -216,7 +234,10 @@ impl IndexStore for LanceIndexStore {
         let writer = current_writer::FileWriter::try_new(
             writer,
             schema,
-            current_writer::FileWriterOptions::default(),
+            current_writer::FileWriterOptions {
+                format_version: Some(self.file_version),
+                ..Default::default()
+            },
         )?;
         Ok(Box::new(writer))
     }

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -132,10 +132,12 @@ impl LanceIndexStoreExt for LanceIndexStore {
     fn from_dataset_for_new(dataset: &Dataset, uuid: &str) -> Result<Self> {
         let index_dir = dataset.indices_dir().child(uuid);
         let cache = dataset.metadata_cache.file_metadata_cache(&index_dir);
-        Ok(Self::new(
+        let file_version = dataset.manifest.data_storage_format.lance_file_version()?;
+        Ok(Self::new_with_version(
             dataset.object_store.clone(),
             index_dir,
             Arc::new(cache),
+            file_version,
         ))
     }
 
@@ -144,10 +146,12 @@ impl LanceIndexStoreExt for LanceIndexStore {
             .indice_files_dir(index)?
             .child(index.uuid.to_string());
         let cache = dataset.metadata_cache.file_metadata_cache(&index_dir);
-        Ok(Self::new(
+        let file_version = dataset.manifest.data_storage_format.lance_file_version()?;
+        Ok(Self::new_with_version(
             dataset.object_store.clone(),
             index_dir,
             Arc::new(cache),
+            file_version,
         ))
     }
 }


### PR DESCRIPTION
Before this change, index writes always used the default format.