### PR TITLE
fix: treat `https://` proto same as azure when picking a commit handler

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1071,7 +1071,7 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" | "shared-memory" => {
+        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" | "shared-memory" | "https" => {
             Ok(Arc::new(ConditionalPutCommitHandler))
         }
         #[cfg(not(feature = "dynamodb"))]


### PR DESCRIPTION
Without this, it falls back to the unsafe commit handler