### PR TITLE
make opening index size inspection O(1)

### DIFF
--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -49,9 +49,19 @@ pub struct LanceIndexStore {
 
 impl DeepSizeOf for LanceIndexStore {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        self.object_store.deep_size_of_children(context)
-            + self.index_dir.as_ref().deep_size_of_children(context)
-            + self.metadata_cache.deep_size_of_children(context)
+        // Only count data this store actually owns. `object_store`, `metadata_cache`
+        // and `scheduler` are `Arc`s to process-wide shared infrastructure, not data
+        // owned by the index. Counting `metadata_cache` here is doubly wrong:
+        //   - Correctness: a cached `BTreeIndex` reaches this store via `Arc`, so each
+        //     index entry would be charged the entire shared metadata cache — inflating
+        //     (and equalizing) index-cache entry weights so size-based eviction evicts
+        //     indexes immediately and re-opens them on every query.
+        //   - Cost: it makes each index-cache insert walk the metadata cache
+        //     (`approx_size_bytes` iterates all entries), i.e. O(metadata-cache size).
+        // This mirrors `BTreeIndex::deep_size_of_children`, which already skips its
+        // `index_cache` field to avoid circular references.
+        self.index_dir.as_ref().deep_size_of_children(context)
+            + self.file_sizes.deep_size_of_children(context)
     }
 }
 


### PR DESCRIPTION
## Problem

`LanceIndexStore::deep_size_of_children` counted `object_store` + `index_dir` + `metadata_cache`. `object_store` and `metadata_cache` are `Arc`s to process-wide **shared** infrastructure, not data the index owns.

A cached `BTreeIndex` reaches its `LanceIndexStore` (and thus `metadata_cache`) via `Arc`, so moka's byte-weigher — which calls `deep_size_of()` on **every index-cache insert** — walked the *entire shared metadata cache* to weigh a *single* index. Two consequences:

1. **Cost:** each scalar-index open became **O(metadata-cache size)** (`LanceCache::deep_size_of_children` → `approx_size_bytes()` iterates every entry). On a large shared cache this dominates CPU.
2. **Mis-weighting:** every index entry was charged ≈ the whole metadata cache, inflating and equalizing index-cache entry weights, so size-based eviction evicted index *objects* almost immediately and re-opened them on nearly every query.

In production this showed up as `open_scalar_index` on essentially every query, each paying the O(metadata-cache) walk.

## Fix

Count only data the store owns: `index_dir + file_sizes`. This mirrors `BTreeIndex::deep_size_of_children`, which already skips its `index_cache` field to avoid circular references.

It deliberately does **not** touch `approx_size_bytes` / `LanceCache::deep_size_of_children` (no `weighted_size`), so it carries no telemetry-accuracy tradeoff — the per-open path simply never reaches the cache.

## Testing done

Microbenchmark timing the real `LanceIndexStore::deep_size_of()` vs metadata-cache fill N (`release-7.0.0` vs this branch, same harness):

| N (metadata entries) | release-7.0.0 | this fix |
|---:|---:|---:|
| 1 | 5.6 µs | ~1 ns |
| 1,000 | 91 µs | ~1 ns |
| 10,000 | 767 µs | ~1 ns |
| 100,000 | 19.5 ms | ~1 ns |

O(N) → O(1), independent of cache fill.

* stack testing - WIP