### PR TITLE
Add tracing spans to file compaction phases

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - release/**
+      - release-* # Rerun fork release branches (e.g. release-7.0.0)
   pull_request:
     branches:
       - main
       - release/**
+      - release-* # Rerun fork release branches (e.g. release-7.0.0)
     paths:
       - java/**
       - rust/**

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - release/**
+      - release-* # Rerun fork release branches (e.g. release-7.0.0)
   pull_request:
     branches:
       - main
       - release/**
+      - release-* # Rerun fork release branches (e.g. release-7.0.0)
     paths:
       - Cargo.*
       - python/**

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - main
       - release/**
+      - release-* # Rerun fork release branches (e.g. release-7.0.0)
   pull_request:
     branches:
       - main
       - release/**
+      - release-* # Rerun fork release branches (e.g. release-7.0.0)
     paths:
       - rust/**
       - protos/**

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -66,7 +66,7 @@ use std::num::NonZero;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
-use tracing::{info, instrument};
+use tracing::{Instrument as _, info, instrument};
 
 pub(crate) mod blob;
 mod branch_location;
@@ -993,9 +993,13 @@ impl Dataset {
     }
 
     pub async fn latest_manifest(&self) -> Result<(Arc<Manifest>, ManifestLocation)> {
+        // This resolves the newest version, which for object-store commit handling lists the
+        // version directory — its cost grows with the number of (un-cleaned) versions, so it's
+        // worth seeing on its own in a trace.
         let location = self
             .commit_handler
             .resolve_latest_location(&self.base, &self.object_store)
+            .instrument(tracing::info_span!("resolve_latest_location"))
             .await?;
 
         // Check if manifest is in cache before reading from storage

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -110,7 +110,7 @@ use lance_index::frag_reuse::FragReuseGroup;
 use lance_table::format::{Fragment, RowIdMeta};
 use roaring::{RoaringBitmap, RoaringTreemap};
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tracing::{Instrument as _, info, instrument, warn};
 
 mod binary_copy;
 pub mod remapping;
@@ -754,7 +754,17 @@ pub async fn compact_files_with_planner(
     remap_options: Option<Arc<dyn IndexRemapperOptions>>, // These will be deprecated later
     planner: &dyn CompactionPlanner,
 ) -> Result<CompactionMetrics> {
-    let compaction_plan: CompactionPlan = planner.plan(dataset).await?;
+    // Phase 1: planning. Decides which fragments are grouped into rewrite tasks.
+    let compaction_plan: CompactionPlan = async {
+        let plan = planner.plan(dataset).await?;
+        tracing::Span::current().record("num_tasks", plan.num_tasks());
+        Ok::<_, Error>(plan)
+    }
+    .instrument(tracing::info_span!(
+        "plan_compaction",
+        num_tasks = tracing::field::Empty
+    ))
+    .await?;
 
     // If nothing to compact, don't make a commit.
     if compaction_plan.tasks().is_empty() {
@@ -763,6 +773,7 @@ pub async fn compact_files_with_planner(
 
     let dataset_ref = &dataset.clone();
 
+    // Phase 2: rewrite. Tasks run concurrently; each gets its own `rewrite_files` span.
     let result_stream = futures::stream::iter(compaction_plan.tasks.into_iter())
         .map(|task| rewrite_files(Cow::Borrowed(dataset_ref), task, &compaction_plan.options))
         .buffer_unordered(
@@ -773,13 +784,17 @@ pub async fn compact_files_with_planner(
         );
 
     let completed_tasks: Vec<RewriteResult> = result_stream.try_collect().await?;
+    let num_tasks = completed_tasks.len();
     let remap_options = remap_options.unwrap_or(Arc::new(DatasetIndexRemapperOptions::default()));
+
+    // Phase 3: commit. Index remapping + a single transaction replacing the old fragments.
     let metrics = commit_compaction(
         dataset,
         completed_tasks,
         remap_options,
         &compaction_plan.options,
     )
+    .instrument(tracing::info_span!("commit_compaction", num_tasks))
     .await?;
 
     Ok(metrics)
@@ -1121,6 +1136,16 @@ async fn reserve_fragment_ids(
 /// Rewrite the files in a single task.
 ///
 /// This assumes that the dataset is the correct read version to be compacted.
+#[instrument(
+    name = "rewrite_files",
+    skip_all,
+    fields(
+        input_fragments = task.fragments.len(),
+        num_rows = tracing::field::Empty,
+        can_binary_copy = tracing::field::Empty,
+        new_fragments = tracing::field::Empty,
+    )
+)]
 async fn rewrite_files(
     dataset: Cow<'_, Dataset>,
     task: TaskData,
@@ -1165,6 +1190,9 @@ async fn rewrite_files(
     );
     let mode = options.compaction_mode();
     let can_binary_copy = can_use_binary_copy(dataset.as_ref(), options, &fragments).await;
+    tracing::Span::current()
+        .record("num_rows", num_rows)
+        .record("can_binary_copy", can_binary_copy);
     if !can_binary_copy && matches!(mode, CompactionMode::ForceBinaryCopy) {
         return Err(Error::not_supported_source(
             format!("compaction task {}: binary copy is not supported", task_id).into(),
@@ -1298,6 +1326,7 @@ async fn rewrite_files(
         .map(|f| f.files.len() + f.deletion_file.is_some() as usize)
         .sum();
 
+    tracing::Span::current().record("new_fragments", new_fragments.len());
     log::info!("Compaction task {}: completed", task_id);
 
     Ok(RewriteResult {

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1173,7 +1173,9 @@ async fn rewrite_files(
     // It's possible the fragments are old and don't have physical rows or
     // num deletions recorded. If that's the case, we need to grab and set that
     // information.
-    let fragments = migrate_fragments(dataset.as_ref(), &task.fragments, recompute_stats).await?;
+    let fragments = migrate_fragments(dataset.as_ref(), &task.fragments, recompute_stats)
+        .instrument(tracing::info_span!("migrate_fragments"))
+        .await?;
     let num_rows = fragments
         .iter()
         .map(|f| f.physical_rows.unwrap() as u64)
@@ -1209,6 +1211,7 @@ async fn rewrite_files(
             true,
             needs_remapping,
         )
+        .instrument(tracing::info_span!("prepare_reader"))
         .await?;
         row_ids_rx = rx_initial;
 
@@ -1250,6 +1253,7 @@ async fn rewrite_files(
             &params,
             options.binary_copy_read_batch_bytes,
         )
+        .instrument(tracing::info_span!("rewrite_files_binary_copy"))
         .await?;
 
         if new_fragments.is_empty() && matches!(mode, CompactionMode::ForceBinaryCopy) {
@@ -1277,6 +1281,8 @@ async fn rewrite_files(
             row_ids_rx = Some(rx);
         }
     } else {
+        // `reader` is lazy, so this span covers both the scan (reads) and the writes — they are
+        // fused in the streaming pipeline and can't be timed apart here.
         let (frags, _) = write_fragments_internal(
             Some(dataset.as_ref()),
             dataset.object_store.clone(),
@@ -1286,6 +1292,7 @@ async fn rewrite_files(
             params,
             None,
         )
+        .instrument(tracing::info_span!("write_fragments"))
         .await?;
         new_fragments = frags;
     }
@@ -1303,12 +1310,17 @@ async fn rewrite_files(
     } else {
         if dataset.manifest.uses_stable_row_ids() {
             log::info!("Compaction task {}: rechunking stable row ids", task_id);
-            rechunk_stable_row_ids(dataset.as_ref(), &mut new_fragments, &fragments).await?;
-            recalc_versions_for_rewritten_fragments(
-                dataset.as_ref(),
-                &mut new_fragments,
-                &fragments,
-            )
+            async {
+                rechunk_stable_row_ids(dataset.as_ref(), &mut new_fragments, &fragments).await?;
+                recalc_versions_for_rewritten_fragments(
+                    dataset.as_ref(),
+                    &mut new_fragments,
+                    &fragments,
+                )
+                .await?;
+                Ok::<_, Error>(())
+            }
+            .instrument(tracing::info_span!("rechunk_stable_row_ids"))
             .await?;
         }
         None


### PR DESCRIPTION
## What

`compact_files` (`compact_files_with_planner`) ran as a single opaque span in our telemetry. A multi-hour compaction pass showed up as one number with no way to see where the time went.

This breaks it into the three phases that actually do work, each with its own span:

| Span | Fields |
|---|---|
| `plan_compaction` | `num_tasks` |
| `rewrite_files` (one per task, run concurrently) | `input_fragments`, `num_rows`, `can_binary_copy`, `new_fragments` |
| `commit_compaction` | `num_tasks` |

## Why

We hit a maintenance pass where a single dataset's compaction took ~80 minutes and there was zero visibility below the top-level call. With per-task spans, a slow pass can be attributed to a specific task and row count instead of guessed at, and the plan/rewrite/commit split shows which phase dominates.

This is purely additive instrumentation — no behavior change. Based on `release-7.0.0` (the branch the Rerun dataplatform patches against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)