### PR TITLE
fix: avoid panic due to empty IO buffers on tokio runtime shutdown

### DIFF
--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -265,6 +265,7 @@ struct MutableBatch<F: FnOnce(Response) + Send> {
     num_bytes: u64,
     priority: u128,
     num_reqs: usize,
+    num_delivered: usize,
     err: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     // When true, report 0 bytes consumed so the backpressure budget is unaffected
     bypass_backpressure: bool,
@@ -284,6 +285,7 @@ impl<F: FnOnce(Response) + Send> MutableBatch<F> {
             num_bytes: 0,
             priority,
             num_reqs,
+            num_delivered: 0,
             err: None,
             bypass_backpressure,
         }
@@ -296,9 +298,16 @@ impl<F: FnOnce(Response) + Send> MutableBatch<F> {
 // data.
 impl<F: FnOnce(Response) + Send> Drop for MutableBatch<F> {
     fn drop(&mut self) {
-        // If we have an error, return that.  Otherwise return the data
-        let result = if self.err.is_some() {
-            Err(Error::wrapped(self.err.take().unwrap()))
+        // If we have an error, return that. Otherwise return the data, as long as the I/O requests have been processed.
+        let result = if let Some(err) = self.err.take() {
+            Err(Error::wrapped(err))
+        } else if self.num_delivered < self.data_buffers.len() {
+            // This usually happens on tokio runtime shutdown
+            Err(Error::io(format!(
+                "I/O request was dropped before completion ({} of {} reads delivered)",
+                self.num_delivered,
+                self.data_buffers.len()
+            )))
         } else {
             let mut data = Vec::new();
             std::mem::swap(&mut data, &mut self.data_buffers);
@@ -335,6 +344,7 @@ impl<F: FnOnce(Response) + Send> DataSink for MutableBatch<F> {
     // Called by worker tasks to add data to the MutableBatch
     fn deliver_data(&mut self, data: DataChunk) {
         self.num_bytes += data.num_bytes;
+        self.num_delivered += 1;
         match data.data {
             Ok(data_bytes) => {
                 self.data_buffers[data.task_idx] = data_bytes;
@@ -1050,6 +1060,26 @@ mod tests {
             .collect();
 
         assert_eq!(order, vec![(5, true), (20, true), (1, false), (10, false)]);
+    }
+
+    #[test]
+    fn test_batch_with_undelivered_slot_is_error() {
+        let response = Arc::new(Mutex::new(None));
+        let response_clone = response.clone();
+        let batch = MutableBatch::new(
+            move |rsp| *response_clone.lock().unwrap() = Some(rsp),
+            2, // num_data_buffers
+            0, // priority
+            2, // num_reqs
+            false,
+        );
+        drop(batch);
+
+        let data = response.lock().unwrap().take().unwrap().data;
+        assert!(
+            data.is_err(),
+            "undelivered slot must yield an error, got {data:?}",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Previously, shutting down an application with concurrent reads ongoing caused a panic that looks something like this:
```
 Panic!, thread_name: "tokio-rt-worker", msg: Some("range end out of bounds: 128 <= 0"), file_line: Some("/home/ilya/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytes-1.11.1/src/bytes.rs:392"), backtrace:   
    ...
   6: bytes::bytes::Bytes::slice
   7: lance_io::scheduler::FileScheduler::submit_request::{{closure}}
   8: <lance_file::io::LanceEncodingsIo as lance_encoding::EncodingsIo>::submit_request::{{closure}}
   9: <core::pin::Pin<P> as core::future::future::Future>::poll
  10: <lance_encoding::encodings::logical::primitive::MiniBlockScheduler as lance_encoding::encodings::logical::primitive::StructuralPageScheduler>::schedule_ranges::{{closure}}
  11: <core::pin::Pin<P> as core::future::future::Future>::poll
  12: <lance_encoding::encodings::logical::primitive::StructuralPrimitiveFieldSchedulingJob as lance_encoding::decoder::StructuralSchedulingJob>::schedule_next::{{closure}}::{{closure}}
  13: <core::pin::Pin<P> as core::future::future::Future>::poll
```

This was caused by `MutableBatch` returning an empty buffer on Drop, if it did not yet receive any data.