### PR TITLE
revert: "perf(merge_insert): probe every indexed key column for composite joins (#6878)"

### DIFF
--- a/rust/lance/benches/merge_insert.rs
+++ b/rust/lance/benches/merge_insert.rs
@@ -15,9 +15,6 @@
 //! computation. The other shapes (`clean`, `with_new_rows_only`,
 //! `with_deletions_only`) skip that branch and serve as controls.
 //!
-//! The `composite_key_indexed` shape covers merge_insert joined on two
-//! indexed key columns, which probes every index and AND-folds the results.
-//!
 //! Run with `cargo bench --bench merge_insert`.
 
 use std::sync::Arc;
@@ -130,90 +127,6 @@ async fn one_merge_insert(ds: Arc<Dataset>, base_existing: i64, base_new: i64) {
     let _ = job.execute_reader(reader).await.unwrap();
 }
 
-// --- Composite-key shape: join on (a, b) with a BTree index on each key ---
-//
-// Exercises the multi-index probe path: one `IsIn` query per indexed key
-// column, AND-folded inside a single `MapIndexExec`, followed by the
-// composite hash join.  `b` is a deterministic function of `a` so source
-// rows can target existing composite keys without tracking extra state.
-
-fn composite_schema() -> Arc<ArrowSchema> {
-    Arc::new(ArrowSchema::new(vec![
-        Field::new("a", DataType::Int64, false),
-        Field::new("b", DataType::Int64, false),
-    ]))
-}
-
-fn composite_b(a: i64) -> i64 {
-    a * 7 + 3
-}
-
-fn make_composite_batch(start: i64, n: usize) -> RecordBatch {
-    let a = Int64Array::from_iter_values(start..start + n as i64);
-    let b = Int64Array::from_iter_values((start..start + n as i64).map(composite_b));
-    RecordBatch::try_new(composite_schema(), vec![Arc::new(a), Arc::new(b)]).unwrap()
-}
-
-async fn build_composite_key_indexed() -> (TempStrDir, Arc<Dataset>) {
-    let dir = TempStrDir::default();
-    let path = dir.as_str().to_string();
-    let total = ROWS_PER_FRAG * NUM_FRAGS;
-    let mut batches = Vec::new();
-    let mut start = 0i64;
-    while (start as u64) < total {
-        let n = (total - start as u64).min(ROWS_PER_FRAG) as usize;
-        batches.push(make_composite_batch(start, n));
-        start += n as i64;
-    }
-    let params = WriteParams {
-        max_rows_per_file: ROWS_PER_FRAG as usize,
-        max_rows_per_group: ROWS_PER_FRAG as usize,
-        mode: WriteMode::Create,
-        ..Default::default()
-    };
-    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), composite_schema());
-    Dataset::write(reader, &path, Some(params)).await.unwrap();
-
-    let mut ds = Dataset::open(&path).await.unwrap();
-    for col in ["a", "b"] {
-        ds.create_index(
-            &[col],
-            IndexType::BTree,
-            None,
-            &ScalarIndexParams::default(),
-            true,
-        )
-        .await
-        .unwrap();
-    }
-    (dir, Arc::new(ds))
-}
-
-/// Composite-key merge_insert op: 30 updates of existing (a, b) pairs +
-/// 70 inserts of new pairs, joined on both columns.
-async fn one_composite_merge_insert(ds: Arc<Dataset>, base_existing: i64, base_new: i64) {
-    let mut a_vals: Vec<i64> = (0..30).map(|i| base_existing + i).collect();
-    a_vals.extend(base_new..base_new + 70);
-    let b_vals: Vec<i64> = a_vals.iter().copied().map(composite_b).collect();
-    let batch = RecordBatch::try_new(
-        composite_schema(),
-        vec![
-            Arc::new(Int64Array::from(a_vals)),
-            Arc::new(Int64Array::from(b_vals)),
-        ],
-    )
-    .unwrap();
-    let reader = RecordBatchIterator::new(std::iter::once(Ok(batch)), composite_schema());
-
-    let mut builder =
-        MergeInsertBuilder::try_new(ds, vec!["a".to_string(), "b".to_string()]).unwrap();
-    builder
-        .when_matched(WhenMatched::UpdateAll)
-        .when_not_matched(WhenNotMatched::InsertAll);
-    let job = builder.try_build().unwrap();
-    let _ = job.execute_reader(reader).await.unwrap();
-}
-
 async fn build_clean() -> (TempStrDir, Arc<Dataset>) {
     let dir = TempStrDir::default();
     let path = dir.as_str().to_string();
@@ -248,12 +161,10 @@ async fn build_with_new_rows_and_deletions() -> (TempStrDir, Arc<Dataset>) {
     (dir, Arc::new(ds))
 }
 
-fn bench_one_shape<F, Fut, M, MFut>(c: &mut Criterion, name: &str, builder: F, merge: M)
+fn bench_one_shape<F, Fut>(c: &mut Criterion, name: &str, builder: F)
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = (TempStrDir, Arc<Dataset>)>,
-    M: Fn(Arc<Dataset>, i64, i64) -> MFut + Copy,
-    MFut: std::future::Future<Output = ()>,
 {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let (_dir, ds) = rt.block_on(builder());
@@ -272,40 +183,29 @@ where
                 bench_ds.restore().await.unwrap();
                 let arc = Arc::new(bench_ds);
                 // base_existing in the indexed range, base_new beyond all data so it's an insert.
-                merge(arc, 100, total + 1_000_000).await;
+                one_merge_insert(arc, 100, total + 1_000_000).await;
             })
         })
     });
 }
 
 fn bench_merge_insert(c: &mut Criterion) {
-    bench_one_shape(c, "merge_insert/clean", build_clean, one_merge_insert);
+    bench_one_shape(c, "merge_insert/clean", build_clean);
     bench_one_shape(
         c,
         "merge_insert/with_new_rows_only",
         build_with_new_rows_only,
-        one_merge_insert,
     );
     bench_one_shape(
         c,
         "merge_insert/with_deletions_only",
         build_with_deletions_only,
-        one_merge_insert,
     );
     // The shape that exercises the AllowList(Full) - BlockList(Partial) path.
     bench_one_shape(
         c,
         "merge_insert/with_new_rows_and_deletions",
         build_with_new_rows_and_deletions,
-        one_merge_insert,
-    );
-    // Composite key joined on (a, b), both BTree-indexed: exercises the
-    // AND-folded multi-index probe inside MapIndexExec.
-    bench_one_shape(
-        c,
-        "merge_insert/composite_key_indexed",
-        build_composite_key_indexed,
-        one_composite_merge_insert,
     );
 }
 

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -58,9 +58,7 @@ use crate::{
     },
     index::DatasetIndexInternalExt,
     io::exec::{
-        AddRowAddrExec, Planner, TakeExec, project,
-        scalar_index::{IndexLookup, MapIndexExec},
-        utils::ReplayExec,
+        AddRowAddrExec, Planner, TakeExec, project, scalar_index::MapIndexExec, utils::ReplayExec,
     },
 };
 use arrow_array::{
@@ -123,7 +121,6 @@ use lance_table::format::{Fragment, IndexMetadata, RowIdMeta};
 use log::info;
 use roaring::RoaringTreemap;
 use snafu::ResultExt;
-use std::collections::HashMap;
 use std::{
     collections::{BTreeMap, HashSet},
     sync::{
@@ -627,67 +624,30 @@ impl MergeInsertJob {
             .map(|_| SchemaComparison::Subschema)
     }
 
-    /// Collect every join column that has a scalar index supporting exact
-    /// equality.
-    ///
-    /// For a single-column join this matches the previous behavior. For a
-    /// multi-column (composite key) join, every indexed column contributes
-    /// an additional `IsIn` probe inside one [`MapIndexExec`]: their AND
-    /// yields the row addresses where every indexed column matches some
-    /// source value. The downstream hash join still filters by the full
-    /// composite key, so unindexed columns simply do not prune the
-    /// candidate set — they are checked by the post-filter.
-    ///
-    /// Returns an empty vec when no join column has a usable scalar index;
-    /// callers should then fall through to the full-scan path.
-    async fn indexed_join_keys(&self) -> Result<Vec<(String, IndexMetadata)>> {
-        let mut indexed = Vec::with_capacity(self.params.on.len());
-        for col in &self.params.on {
-            if let Some(idx) = self
-                .dataset
+    async fn join_key_as_scalar_index(&self) -> Result<Option<IndexMetadata>> {
+        if self.params.on.len() != 1 {
+            // joining on more than one column
+            Ok(None)
+        } else {
+            let col = &self.params.on[0];
+            self.dataset
                 .load_scalar_index(
                     IndexCriteria::default()
                         .for_column(col)
                         // Unclear if this would work if the index does not support exact equality
                         .supports_exact_equality(),
                 )
-                .await?
-            {
-                indexed.push((col.clone(), idx));
-            }
+                .await
         }
-        Ok(indexed)
-    }
-
-    /// Fragments that cannot be reached by every index in `indexed_keys`
-    /// and therefore must be scanned separately and unioned in alongside
-    /// the indexed take.  A fragment is "reachable" by the composite probe
-    /// only if it is in the intersection of all the indices' fragment
-    /// bitmaps; everything else falls into the unindexed set.
-    async fn unindexed_fragments_for_keys(
-        &self,
-        indexed_keys: &[(String, IndexMetadata)],
-    ) -> Result<Vec<Fragment>> {
-        let mut unindexed: HashMap<u64, Fragment> = HashMap::new();
-        for (_, index) in indexed_keys {
-            for frag in self.dataset.unindexed_fragments(&index.name).await? {
-                unindexed.entry(frag.id).or_insert(frag);
-            }
-        }
-        Ok(unindexed.into_values().collect())
     }
 
     async fn create_indexed_scan_joined_stream(
         &self,
         source: SendableRecordBatchStream,
-        indexed_keys: Vec<(String, IndexMetadata)>,
+        index: IndexMetadata,
     ) -> Result<SendableRecordBatchStream> {
         // This relies on a few non-standard physical operators and so we cannot use the
         // datafusion dataframe API and need to construct the plan manually :'(
-        debug_assert!(
-            !indexed_keys.is_empty(),
-            "create_indexed_scan_joined_stream requires at least one indexed key"
-        );
         let schema = source.schema();
         let add_row_addr = match self.check_compatible_schema(&schema)? {
             SchemaComparison::FullCompatible => false,
@@ -702,25 +662,22 @@ impl MergeInsertJob {
         // the new data into memory.  In the future, we can do better
         let shared_input = Arc::new(ReplayExec::new(Capacity::Unbounded, input));
 
-        // 3 - Probe every indexed join column.  For composite keys this is
-        //     the AND of one `IsIn` query per indexed column, which yields
-        //     a tighter candidate set than probing a single column.  The
-        //     downstream hash join still filters by the full composite key,
-        //     so unindexed `on` columns simply do not prune the candidates.
-        let lookup_fields = indexed_keys
-            .iter()
-            .map(|(col, _)| Ok(schema.field_with_name(col)?.clone()))
-            .collect::<Result<Vec<_>>>()?;
-        let index_mapper_input =
-            Arc::new(project(shared_input.clone(), &Schema::new(lookup_fields))?);
+        // 3 - Use the index to map input to row addresses
+        // First, we need to project to the key column
+        let field = schema.field_with_name(&self.params.on[0])?;
+        let index_mapper_input = Arc::new(project(
+            shared_input.clone(),
+            // schema for only the key join column
+            &Schema::new(vec![field.clone()]),
+        )?);
 
-        let lookups = indexed_keys
-            .iter()
-            .map(|(col, idx)| IndexLookup::new(col.clone(), idx.name.clone()))
-            .collect::<Vec<_>>();
-        let mut index_mapper: Arc<dyn ExecutionPlan> = Arc::new(MapIndexExec::new_multi(
+        // Then we pass the key column into the index mapper
+        let index_column = self.params.on[0].clone();
+        let mut index_mapper: Arc<dyn ExecutionPlan> = Arc::new(MapIndexExec::new(
+            // create index from original data and key column
             self.dataset.clone(),
-            lookups,
+            index_column.clone(),
+            index.name.clone(),
             index_mapper_input,
         ));
 
@@ -765,12 +722,8 @@ impl MergeInsertJob {
             .filter(|name| name.as_str() != ROW_ID && name.as_str() != ROW_ADDR)
             .collect::<Vec<_>>();
 
-        // 5a - We also need to scan any new unindexed data and union it in.
-        //      A row can be reached by the composite index probe only if it
-        //      lives in a fragment covered by *every* chosen index, so the
-        //      "unindexed" set is the union of fragments missing from any
-        //      one of them.
-        let unindexed_fragments = self.unindexed_fragments_for_keys(&indexed_keys).await?;
+        // 5a - We also need to scan any new unindexed data and union it in
+        let unindexed_fragments = self.dataset.unindexed_fragments(&index.name).await?;
         if !unindexed_fragments.is_empty() {
             let mut builder = self.dataset.scan();
             if add_row_addr {
@@ -795,47 +748,22 @@ impl MergeInsertJob {
         // field names (DF doesn't support this as of version 44)
         target = Self::prefix_columns_phys(target, "target_");
 
-        // 6 - Join the source against the taken target rows on the full
-        //     composite key.  Probing the index produces a super-set of the
-        //     actual matches (when not every key column has an index, or
-        //     even when they do — the per-column `IsIn` lists do not
-        //     correlate values across the tuple), so this join is what
-        //     trims candidates down to the exact composite-key matches.
-        let on_keys = self
-            .params
-            .on
-            .iter()
-            .map(|col| {
-                let source_key = Column::new_with_schema(col, shared_input.schema().as_ref())?;
-                let target_key =
-                    Column::new_with_schema(&format!("target_{}", col), target.schema().as_ref())?;
-                Ok::<_, Error>((
-                    Arc::new(source_key) as Arc<dyn PhysicalExpr>,
-                    Arc::new(target_key) as Arc<dyn PhysicalExpr>,
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // Use standard SQL NULL semantics for composite keys so this path
-        // produces the same result as the full-scan path.  The
-        // single-column case keeps its historical `NullEqualsNull` behavior
-        // to avoid changing semantics for existing callers.
-        let null_equality = if self.params.on.len() == 1 {
-            NullEquality::NullEqualsNull
-        } else {
-            NullEquality::NullEqualsNothing
-        };
-
+        // 6 - Finally, join the input (source table) with the taken data (target table)
+        let source_key = Column::new_with_schema(&index_column, shared_input.schema().as_ref())?;
+        let target_key = Column::new_with_schema(
+            &format!("target_{}", index_column),
+            target.schema().as_ref(),
+        )?;
         let joined = Arc::new(
             HashJoinExec::try_new(
                 shared_input,
                 target,
-                on_keys,
+                vec![(Arc::new(source_key), Arc::new(target_key))],
                 None,
                 &JoinType::Full,
                 None,
                 PartitionMode::CollectLeft,
-                null_equality,
+                NullEquality::NullEqualsNull,
                 false,
             )
             .unwrap(),
@@ -954,11 +882,8 @@ impl MergeInsertJob {
             )
         {
             // keeping unmatched rows, no deletion
-            let indexed_keys = self.indexed_join_keys().await?;
-            if !indexed_keys.is_empty() {
-                return self
-                    .create_indexed_scan_joined_stream(source, indexed_keys)
-                    .await;
+            if let Some(index) = self.join_key_as_scalar_index().await? {
+                return self.create_indexed_scan_joined_stream(source, index).await;
             }
         }
 
@@ -1693,7 +1618,7 @@ impl MergeInsertJob {
                 self.params.delete_not_matched_by_source,
                 WhenNotMatchedBySource::Keep
             ) {
-            !self.indexed_join_keys().await?.is_empty()
+            self.join_key_as_scalar_index().await?.is_some()
         } else {
             false
         };
@@ -3771,368 +3696,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(ds.count_rows(None).await.unwrap(), 2048);
-    }
-
-    /// Multi-column (composite key) merge_insert when one or more join
-    /// columns have a scalar index.  Before this change the indexed path
-    /// was hard-gated to single-column joins; composite-key merges fell
-    /// through to a full target scan even when every key column was
-    /// indexed.  Now each indexed column contributes an AND-ed `IsIn`
-    /// probe inside one `MapIndexExec`, and the downstream hash join trims
-    /// the candidates to the exact composite-key matches — rows that
-    /// happen to match one key column but not the other must NOT be
-    /// touched.
-    #[rstest::rstest]
-    #[case::index_on_first(true, false)]
-    #[case::index_on_second(false, true)]
-    #[case::index_on_both(true, true)]
-    #[tokio::test]
-    async fn test_indexed_merge_insert_composite_key(
-        #[case] index_on_a: bool,
-        #[case] index_on_b: bool,
-    ) {
-        // Target rows: every (a, b) combination from {1,2} x {10,20}.
-        let initial = record_batch!(
-            ("a", Int32, [1, 1, 2, 2]),
-            ("b", Int32, [10, 20, 10, 20]),
-            ("value", Int32, [100, 200, 300, 400])
-        )
-        .unwrap();
-        let schema = initial.schema();
-
-        let mut ds = Dataset::write(
-            RecordBatchIterator::new(vec![Ok(initial.clone())], schema.clone()),
-            "memory://",
-            None,
-        )
-        .await
-        .unwrap();
-
-        let params = ScalarIndexParams::default();
-        if index_on_a {
-            ds.create_index(&["a"], IndexType::Scalar, None, &params, false)
-                .await
-                .unwrap();
-        }
-        if index_on_b {
-            ds.create_index(&["b"], IndexType::Scalar, None, &params, false)
-                .await
-                .unwrap();
-        }
-
-        // Update (1, 10) and insert (3, 30).  A naive single-column probe
-        // on `a` would also pull (1, 20) into the candidate set; the
-        // composite hash join must keep (1, 20) untouched.
-        let source = record_batch!(
-            ("a", Int32, [1, 3]),
-            ("b", Int32, [10, 30]),
-            ("value", Int32, [999, 333])
-        )
-        .unwrap();
-
-        let (updated_ds, stats) =
-            MergeInsertBuilder::try_new(Arc::new(ds), vec!["a".to_string(), "b".to_string()])
-                .unwrap()
-                .when_matched(WhenMatched::UpdateAll)
-                .when_not_matched(WhenNotMatched::InsertAll)
-                .try_build()
-                .unwrap()
-                .execute_reader(Box::new(RecordBatchIterator::new(
-                    vec![Ok(source.clone())],
-                    source.schema(),
-                )))
-                .await
-                .unwrap();
-
-        assert_eq!(stats.num_updated_rows, 1);
-        assert_eq!(stats.num_inserted_rows, 1);
-        assert_eq!(updated_ds.count_rows(None).await.unwrap(), 5);
-
-        let untouched = updated_ds
-            .count_rows(Some("a = 1 AND b = 20 AND value = 200".to_string()))
-            .await
-            .unwrap();
-        assert_eq!(
-            untouched, 1,
-            "(1, 20) must not be clobbered by an `a`-only probe"
-        );
-
-        let updated = updated_ds
-            .count_rows(Some("a = 1 AND b = 10 AND value = 999".to_string()))
-            .await
-            .unwrap();
-        assert_eq!(updated, 1);
-
-        let inserted = updated_ds
-            .count_rows(Some("a = 3 AND b = 30 AND value = 333".to_string()))
-            .await
-            .unwrap();
-        assert_eq!(inserted, 1);
-    }
-
-    /// Composite key merge_insert with no scalar index on any join column
-    /// must keep working via the full-scan fallback.  Guards against the
-    /// indexed path becoming a hard requirement after this optimization.
-    #[tokio::test]
-    async fn test_indexed_merge_insert_composite_key_no_index() {
-        let initial = record_batch!(
-            ("a", Int32, [1, 1, 2]),
-            ("b", Int32, [10, 20, 10]),
-            ("value", Int32, [100, 200, 300])
-        )
-        .unwrap();
-        let schema = initial.schema();
-
-        let ds = Dataset::write(
-            RecordBatchIterator::new(vec![Ok(initial.clone())], schema.clone()),
-            "memory://",
-            None,
-        )
-        .await
-        .unwrap();
-
-        let source = record_batch!(
-            ("a", Int32, [1]),
-            ("b", Int32, [20]),
-            ("value", Int32, [999])
-        )
-        .unwrap();
-
-        let (updated_ds, stats) =
-            MergeInsertBuilder::try_new(Arc::new(ds), vec!["a".to_string(), "b".to_string()])
-                .unwrap()
-                .when_matched(WhenMatched::UpdateAll)
-                .when_not_matched(WhenNotMatched::InsertAll)
-                .try_build()
-                .unwrap()
-                .execute_reader(Box::new(RecordBatchIterator::new(
-                    vec![Ok(source.clone())],
-                    source.schema(),
-                )))
-                .await
-                .unwrap();
-
-        assert_eq!(stats.num_updated_rows, 1);
-        assert_eq!(stats.num_inserted_rows, 0);
-        let count = updated_ds
-            .count_rows(Some("a = 1 AND b = 20 AND value = 999".to_string()))
-            .await
-            .unwrap();
-        assert_eq!(count, 1);
-    }
-
-    /// Composite-key merge_insert must use standard SQL NULL semantics
-    /// (NULL != NULL) on the post-filter hash join so its behavior is
-    /// identical to the full-scan path; otherwise enabling the indexed
-    /// path for multi-column joins would silently change semantics.
-    #[tokio::test]
-    async fn test_indexed_merge_insert_composite_key_null_semantics() {
-        let initial = record_batch!(
-            ("a", Int32, [Some(1)]),
-            ("b", Utf8, [Option::<&str>::None]),
-            ("value", Int32, [Some(10)])
-        )
-        .unwrap();
-        let schema = initial.schema();
-
-        let mut ds = Dataset::write(
-            RecordBatchIterator::new(vec![Ok(initial.clone())], schema.clone()),
-            "memory://",
-            None,
-        )
-        .await
-        .unwrap();
-
-        ds.create_index(
-            &["a"],
-            IndexType::Scalar,
-            None,
-            &ScalarIndexParams::default(),
-            false,
-        )
-        .await
-        .unwrap();
-
-        let source = record_batch!(
-            ("a", Int32, [Some(1)]),
-            ("b", Utf8, [Option::<&str>::None]),
-            ("value", Int32, [Some(99)])
-        )
-        .unwrap();
-
-        let (updated_ds, stats) =
-            MergeInsertBuilder::try_new(Arc::new(ds), vec!["a".to_string(), "b".to_string()])
-                .unwrap()
-                .when_matched(WhenMatched::UpdateAll)
-                .when_not_matched(WhenNotMatched::InsertAll)
-                .try_build()
-                .unwrap()
-                .execute_reader(Box::new(RecordBatchIterator::new(
-                    vec![Ok(source.clone())],
-                    source.schema(),
-                )))
-                .await
-                .unwrap();
-
-        assert_eq!(stats.num_inserted_rows, 1);
-        assert_eq!(stats.num_updated_rows, 0);
-        assert_eq!(updated_ds.count_rows(None).await.unwrap(), 2);
-    }
-
-    /// Composite-key merge_insert where new (unindexed) fragments are
-    /// appended after the indices were built.  The indexed take only sees
-    /// fragments covered by every chosen index, so the unindexed remainder
-    /// must be unioned in via a full scan — otherwise updates to rows
-    /// that live in those fragments are silently dropped.
-    #[tokio::test]
-    async fn test_indexed_merge_insert_composite_key_unindexed_fragments() {
-        let first = record_batch!(
-            ("a", Int32, [1, 2]),
-            ("b", Int32, [10, 20]),
-            ("value", Int32, [100, 200])
-        )
-        .unwrap();
-        let schema = first.schema();
-
-        let mut ds = Dataset::write(
-            RecordBatchIterator::new(vec![Ok(first.clone())], schema.clone()),
-            "memory://",
-            Some(WriteParams {
-                max_rows_per_file: 64,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
-        let params = ScalarIndexParams::default();
-        ds.create_index(&["a"], IndexType::Scalar, None, &params, false)
-            .await
-            .unwrap();
-        ds.create_index(&["b"], IndexType::Scalar, None, &params, false)
-            .await
-            .unwrap();
-
-        // Append a fragment AFTER both indices are built.  The new (3, 30)
-        // row lives in a fragment neither index covers, so the indexed
-        // take alone would miss it.
-        let appended = record_batch!(
-            ("a", Int32, [3]),
-            ("b", Int32, [30]),
-            ("value", Int32, [300])
-        )
-        .unwrap();
-        ds.append(
-            RecordBatchIterator::new(vec![Ok(appended.clone())], appended.schema()),
-            None,
-        )
-        .await
-        .unwrap();
-
-        // Source updates one row in the indexed fragment AND one row in
-        // the appended (unindexed) fragment.
-        let source = record_batch!(
-            ("a", Int32, [1, 3]),
-            ("b", Int32, [10, 30]),
-            ("value", Int32, [999, 333])
-        )
-        .unwrap();
-
-        let (updated_ds, stats) =
-            MergeInsertBuilder::try_new(Arc::new(ds), vec!["a".to_string(), "b".to_string()])
-                .unwrap()
-                .when_matched(WhenMatched::UpdateAll)
-                .when_not_matched(WhenNotMatched::InsertAll)
-                .try_build()
-                .unwrap()
-                .execute_reader(Box::new(RecordBatchIterator::new(
-                    vec![Ok(source.clone())],
-                    source.schema(),
-                )))
-                .await
-                .unwrap();
-
-        assert_eq!(
-            stats.num_updated_rows, 2,
-            "row in the unindexed fragment must also be updated"
-        );
-        assert_eq!(stats.num_inserted_rows, 0);
-        assert_eq!(updated_ds.count_rows(None).await.unwrap(), 3);
-    }
-
-    /// Composite-key `MapIndexExec` formats its Display so plans expose
-    /// every probed column, and `with_new_children` round-trips the full
-    /// lookup list rather than collapsing back to a single-column form.
-    /// Lives here (not in scalar_index.rs's tests) so the new lines don't
-    /// pile up in a file with pending upstream conflicts.
-    #[test]
-    fn map_index_exec_multi_lookup_plan_shape() {
-        use crate::io::exec::scalar_index::{IndexLookup, MapIndexExec, ScalarIndexExec};
-        use crate::utils::test::NoContextTestFixture;
-        use datafusion::physical_plan::{ExecutionPlan, displayable};
-        use datafusion::scalar::ScalarValue;
-        use lance_index::scalar::{
-            SargableQuery,
-            expression::{ScalarIndexExpr, ScalarIndexSearch},
-        };
-        use lance_select::result::IndexExprResultWireFormat;
-
-        let fixture = NoContextTestFixture::new();
-        let dataset = Arc::new(fixture.dataset);
-
-        let dummy_input: Arc<dyn ExecutionPlan> = Arc::new(ScalarIndexExec::new(
-            dataset.clone(),
-            ScalarIndexExpr::Query(ScalarIndexSearch {
-                column: "ordered".to_string(),
-                index_name: "ordered_idx".to_string(),
-                index_type: "BTree".to_string(),
-                query: Arc::new(SargableQuery::Equals(ScalarValue::UInt64(Some(1)))),
-                needs_recheck: false,
-                fragment_bitmap: None,
-            }),
-            IndexExprResultWireFormat::default(),
-        ));
-
-        let lookups = vec![
-            IndexLookup::new("a", "a_idx"),
-            IndexLookup::new("b", "b_idx"),
-        ];
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(MapIndexExec::new_multi(
-            dataset.clone(),
-            lookups,
-            dummy_input.clone(),
-        ));
-
-        let rendered = format!("{}", displayable(plan.as_ref()).indent(false));
-        assert!(
-            rendered.contains("IndexedLookup [a, b]"),
-            "multi-lookup Display must list every probed column, got: {rendered}",
-        );
-
-        let rebuilt = plan
-            .with_new_children(vec![dummy_input.clone()])
-            .expect("with_new_children must accept exactly one child");
-        let rebuilt_rendered = format!("{}", displayable(rebuilt.as_ref()).indent(false));
-        assert!(
-            rebuilt_rendered.contains("IndexedLookup [a, b]"),
-            "with_new_children must preserve every lookup, got: {rebuilt_rendered}",
-        );
-
-        // The single-lookup convenience constructor still renders without
-        // the column list, so existing EXPLAIN output is unchanged for
-        // single-column joins.
-        let single: Arc<dyn ExecutionPlan> = Arc::new(MapIndexExec::new(
-            dataset,
-            "ordered".to_string(),
-            "ordered_idx".to_string(),
-            dummy_input,
-        ));
-        let single_rendered = format!("{}", displayable(single.as_ref()).indent(false));
-        assert!(
-            single_rendered.contains("IndexedLookup")
-                && !single_rendered.contains("IndexedLookup ["),
-            "single-lookup Display must not include the column list, got: {single_rendered}",
-        );
     }
 
     mod subcols {

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -256,40 +256,14 @@ impl ExecutionPlan for ScalarIndexExec {
 pub static INDEX_LOOKUP_SCHEMA: LazyLock<SchemaRef> =
     LazyLock::new(|| Arc::new(Schema::new(vec![ROW_ID_FIELD.clone()])));
 
-/// A single scalar-index lookup used by [`MapIndexExec`].
-///
-/// `column` identifies a column whose values will be probed against the
-/// index named `index_name`. Multiple lookups are intersected with logical
-/// AND semantics inside `MapIndexExec`.
-#[derive(Debug, Clone)]
-pub struct IndexLookup {
-    pub column: String,
-    pub index_name: String,
-}
-
-impl IndexLookup {
-    pub fn new(column: impl Into<String>, index_name: impl Into<String>) -> Self {
-        Self {
-            column: column.into(),
-            index_name: index_name.into(),
-        }
-    }
-}
-
 /// An execution node that translates index values into row addresses
 ///
-/// This can be combined with TakeExec to perform an "indexed take".
-///
-/// Multiple `(column, index_name)` lookups can be supplied: the operator
-/// expects one input column per lookup (in matching order) and emits the
-/// row addresses where every column's value is present in its respective
-/// index — that is, the AND of the per-column index probes. This lets a
-/// composite-key join trim the candidate row set with every available
-/// scalar index before the downstream take.
+/// This can be combined with TakeExec to perform an "indexed take"
 #[derive(Debug)]
 pub struct MapIndexExec {
     dataset: Arc<Dataset>,
-    lookups: Vec<IndexLookup>,
+    column_name: String,
+    index_name: String,
     input: Arc<dyn ExecutionPlan>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
@@ -301,49 +275,19 @@ impl DisplayAs for MapIndexExec {
             DisplayFormatType::Default
             | DisplayFormatType::Verbose
             | DisplayFormatType::TreeRender => {
-                write!(f, "IndexedLookup")?;
-                if self.lookups.len() > 1 {
-                    let cols = self
-                        .lookups
-                        .iter()
-                        .map(|l| l.column.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    write!(f, " [{cols}]")?;
-                }
-                Ok(())
+                write!(f, "IndexedLookup")
             }
         }
     }
 }
 
 impl MapIndexExec {
-    /// Convenience constructor for the common single-column case.
     pub fn new(
         dataset: Arc<Dataset>,
         column_name: String,
         index_name: String,
         input: Arc<dyn ExecutionPlan>,
     ) -> Self {
-        Self::new_multi(
-            dataset,
-            vec![IndexLookup::new(column_name, index_name)],
-            input,
-        )
-    }
-
-    /// Build a `MapIndexExec` that probes one or more scalar indices and
-    /// emits the AND of their results. `lookups` must be non-empty and
-    /// `input` must produce one column per lookup, in the same order.
-    pub fn new_multi(
-        dataset: Arc<Dataset>,
-        lookups: Vec<IndexLookup>,
-        input: Arc<dyn ExecutionPlan>,
-    ) -> Self {
-        debug_assert!(
-            !lookups.is_empty(),
-            "MapIndexExec requires at least one index lookup"
-        );
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(INDEX_LOOKUP_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
@@ -352,7 +296,8 @@ impl MapIndexExec {
         ));
         Self {
             dataset,
-            lookups,
+            column_name,
+            index_name,
             input,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
@@ -363,30 +308,18 @@ impl MapIndexExec {
         input: datafusion::physical_plan::SendableRecordBatchStream,
         partition: usize,
         dataset: Arc<Dataset>,
-        lookups: Vec<IndexLookup>,
+        column_name: String,
+        index_name: String,
         index_metrics: Arc<IndexMetrics>,
         metrics_set: ExecutionPlanMetricsSet,
     ) -> datafusion::error::Result<datafusion::physical_plan::SendableRecordBatchStream> {
-        // A row can be found by the composite probe only if it lives in a
-        // fragment covered by *every* index in `lookups`; restrict the
-        // deletion mask to that intersection so we only filter deletes we
-        // could actually see.
-        let mut fragment_bitmap: Option<RoaringBitmap> = None;
-        for lookup in &lookups {
-            let bm = scalar_index_fragment_bitmap(&dataset, &lookup.column, &lookup.index_name)
-                .await?
-                .ok_or_else(|| {
-                    datafusion::error::DataFusionError::Internal(format!(
-                        "IndexedLookupExec: index '{}' on column '{}' disappeared after planning",
-                        lookup.index_name, lookup.column,
-                    ))
-                })?;
-            fragment_bitmap = Some(match fragment_bitmap {
-                None => bm,
-                Some(acc) => acc & bm,
-            });
-        }
-        let fragment_bitmap = fragment_bitmap.expect("MapIndexExec built with no lookups");
+        let fragment_bitmap = scalar_index_fragment_bitmap(&dataset, &column_name, &index_name)
+            .await?
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Internal(format!(
+                    "IndexedLookupExec: index '{index_name}' on column '{column_name}' disappeared after planning"
+                ))
+            })?;
         let deletion_mask_fut =
             DatasetPreFilter::create_restricted_deletion_mask(dataset.clone(), fragment_bitmap);
         let deletion_mask = if let Some(fut) = deletion_mask_fut {
@@ -398,7 +331,8 @@ impl MapIndexExec {
         let baseline = BaselineMetrics::new(&metrics_set, partition);
         let elapsed_compute = baseline.elapsed_compute().clone();
         let stream = input.then(move |batch_result| {
-            let lookups = lookups.clone();
+            let column_name = column_name.clone();
+            let index_name = index_name.clone();
             let dataset = dataset.clone();
             let deletion_mask = deletion_mask.clone();
             let metrics = index_metrics.clone();
@@ -409,7 +343,15 @@ impl MapIndexExec {
                 // the per-batch sargable index evaluation, which is the work
                 // we want attributed here.
                 let _t = elapsed_compute.timer();
-                Self::map_batch(lookups, dataset, deletion_mask, batch, metrics).await
+                Self::map_batch(
+                    column_name,
+                    index_name,
+                    dataset,
+                    deletion_mask,
+                    batch,
+                    metrics,
+                )
+                .await
             }
         });
         let stream = stream.map(move |batch| {
@@ -425,42 +367,27 @@ impl MapIndexExec {
         )))
     }
 
-    /// Build the AND-of-IsIn `ScalarIndexExpr` describing this batch's
-    /// composite lookup: each input column contributes one `IsIn` query
-    /// against its matching index.
-    fn build_query(
-        lookups: &[IndexLookup],
-        batch: &RecordBatch,
-    ) -> datafusion::error::Result<ScalarIndexExpr> {
-        let per_column = lookups.iter().enumerate().map(|(idx, lookup)| {
-            let column = batch.column(idx);
-            let values = (0..column.len())
-                .map(|row| ScalarValue::try_from_array(column, row))
-                .collect::<datafusion::error::Result<Vec<_>>>()?;
-            Ok::<_, datafusion::error::DataFusionError>(ScalarIndexExpr::Query(ScalarIndexSearch {
-                column: lookup.column.clone(),
-                index_name: lookup.index_name.clone(),
-                // Internal IndexedLookup-style query — type is unknown at this layer
-                index_type: String::new(),
-                query: Arc::new(SargableQuery::IsIn(values)),
-                needs_recheck: false,
-                fragment_bitmap: None,
-            }))
-        });
-
-        per_column
-            .reduce(|lhs, rhs| Ok(ScalarIndexExpr::And(Box::new(lhs?), Box::new(rhs?))))
-            .expect("MapIndexExec built with no lookups")
-    }
-
     async fn map_batch(
-        lookups: Vec<IndexLookup>,
+        column_name: String,
+        index_name: String,
         dataset: Arc<Dataset>,
         deletion_mask: Option<Arc<RowAddrMask>>,
         batch: RecordBatch,
         metrics: Arc<IndexMetrics>,
     ) -> datafusion::error::Result<RecordBatch> {
-        let query = Self::build_query(&lookups, &batch)?;
+        let index_vals = batch.column(0);
+        let index_vals = (0..index_vals.len())
+            .map(|idx| ScalarValue::try_from_array(index_vals, idx))
+            .collect::<datafusion::error::Result<Vec<_>>>()?;
+        let query = ScalarIndexExpr::Query(ScalarIndexSearch {
+            column: column_name,
+            index_name,
+            // Internal IndexedLookup-style query — type is unknown at this layer
+            index_type: String::new(),
+            query: Arc::new(SargableQuery::IsIn(index_vals)),
+            needs_recheck: false,
+            fragment_bitmap: None,
+        });
         let query_result = query.evaluate(dataset.as_ref(), metrics.as_ref()).await?;
         if !query_result.is_exact() {
             todo!("Support for non-exact query results as input for merge_insert")
@@ -510,9 +437,10 @@ impl ExecutionPlan for MapIndexExec {
                 "MapIndexExec requires exactly one child".to_string(),
             ))
         } else {
-            Ok(Arc::new(Self::new_multi(
+            Ok(Arc::new(Self::new(
                 self.dataset.clone(),
-                self.lookups.clone(),
+                self.column_name.clone(),
+                self.index_name.clone(),
                 children.into_iter().next().unwrap(),
             )))
         }
@@ -528,7 +456,8 @@ impl ExecutionPlan for MapIndexExec {
             input,
             partition,
             self.dataset.clone(),
-            self.lookups.clone(),
+            self.column_name.clone(),
+            self.index_name.clone(),
             Arc::new(IndexMetrics::new(&self.metrics, partition)),
             self.metrics.clone(),
         );


### PR DESCRIPTION
### Related

This reverts commit 294d48ae0b7886555d3bc914d9c13f61635dda30.

### What

Works around https://github.com/lance-format/lance/issues/7803 in our specific use case.

### Testing

Unit test is in the rerun logic