### PR TITLE
chore: add pull request template to the new default branch (SOC 2)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+### Related
+
+<!--
+Include links to any related issues/PRs in a bulleted list, for example:
+* Closes #1234
+* Part of #1337
+-->
+
+### What
+
+<!--
+Make sure the PR title and labels are set to maximize their usefulness for the
+changelog and our `git log`.
+
+If you have noticed any breaking changes, please document them here and consider
+any migration plan.
+-->
+
+### Testing
+
+<!--
+Explain briefly how you have tested the changes in this PR.
+-->
+
+### Compatibility
+
+<!--
+Will the changes in this PR break forward or backward compatibility in any way?
+If so, please explain how and why it is OK, and consider any migration plan.
+-->


### PR DESCRIPTION
### Summary

The default branch moved from `main` to `release-9.0.0`, and the pull request template only ever existed on `main` — so new PRs against the new default get no template at all. This cherry-picks it across unchanged.