### PR TITLE
Enable CI on our release branches, and fix the test it caught

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - release/**
+      - release-*
   pull_request:
     branches:
       - main
       - release/**
+      - release-*
     paths:
       - docs/**
       - .github/workflows/docs-check.yml

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - release/**
+      - release-*
   pull_request:
     branches:
       - main
       - release/**
+      - release-*
     paths:
       - java/**
       - rust/**
@@ -50,6 +52,8 @@ jobs:
         run: cargo clippy --all-targets --locked -- -D warnings
 
   build-and-test-java:
+    # Rerun fork: `ubuntu-24.04-4x` exists only in the upstream org; see rust.yml.
+    if: github.repository != 'rerun-io/lance'
     runs-on: ubuntu-24.04-4x
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - main
       - release/**
+      - release-*
   pull_request:
     branches:
       - main
       - release/**
+      - release-*
     paths:
       - rust/**
       - python/**

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - main
       - release/**
+      - release-*
   pull_request:
     branches:
       - main
       - release/**
+      - release-*
     paths:
       - rust/**
       - protos/**
@@ -31,6 +33,10 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  # Rerun fork: jobs carrying `if: github.repository != 'rerun-io/lance'` request larger
+  # runners that exist only in the upstream org. A job asking for a label that does not
+  # resolve queues for 24h and is then cancelled, so we skip them rather than let them
+  # hang. See "CI on release branches" in the README.
   format:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -84,6 +90,7 @@ jobs:
           command: check
 
   linux-build:
+    if: github.repository != 'rerun-io/lance'
     runs-on: "ubuntu-24.04-8x"
     timeout-minutes: 75
     env:
@@ -122,6 +129,7 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
   linux-arm:
+    if: github.repository != 'rerun-io/lance'
     runs-on: ubuntu-24.04-arm64-8x
     timeout-minutes: 75
     steps:
@@ -147,6 +155,7 @@ jobs:
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
           cargo test --profile ci --locked --features ${ALL_FEATURES}
   query-integration-tests:
+    if: github.repository != 'rerun-io/lance'
     runs-on: ubuntu-24.04-4x
     timeout-minutes: 75
     env:
@@ -174,6 +183,7 @@ jobs:
         run: |
           cargo test --locked -p lance --no-default-features --features fp16kernels,slow_tests --test integration_tests
   build-no-lock:
+    if: github.repository != 'rerun-io/lance'
     runs-on: ubuntu-24.04-8x
     timeout-minutes: 30
     env:
@@ -199,6 +209,7 @@ jobs:
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
           cargo build --profile ci --benches --features ${ALL_FEATURES} --tests
   mac-build:
+    if: github.repository != 'rerun-io/lance'
     runs-on: warp-macos-14-arm64-6x
     timeout-minutes: 45
     strategy:
@@ -231,6 +242,7 @@ jobs:
         run: |
           cargo check --profile ci --benches --features fp16kernels,cli,dynamodb,substrait
   windows-build:
+    if: github.repository != 'rerun-io/lance'
     runs-on: windows-latest-4x
     defaults:
       run:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - release/**
+      - release-*
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -98,28 +98,41 @@ Guidelines:
 
 Upstream scopes its workflows to `main` and `release/**`, which does not match our hyphenated
 `release-X.Y.Z`. Renaming our branches would be the other way to fix that, but downstream pins to
-them by name, so instead these three checks carry an extra `release-*` branch filter and run on PRs
-into a release branch:
+them by name, so instead the workflows we want carry an extra `release-*` branch filter.
 
-| Workflow                   | What it checks                                     |
-|----------------------------|-----------------------------------------------------|
-| `typos.yml`                | Spelling, whole repo                                 |
-| `license-header-check.yml` | Apache headers under `rust/`, `python/`, `protos/`   |
-| `docs-check.yml`           | `docs/` still builds                                 |
+Two things then decide what actually runs.
 
-Everything else stays off, for two different reasons.
+**Runner labels.** Most of upstream's build and test jobs request larger runners — `ubuntu-24.04-8x`,
+`ubuntu-24.04-arm64-8x`, `ubuntu-24.04-4x`, `warp-macos-14-arm64-6x`, `windows-latest-4x` — that exist
+only in the upstream org. **A job requesting a label that does not resolve queues for 24 hours and is
+then cancelled**, which is why the Rust and Python runs on `rerun/main` have never gone green. Those
+jobs therefore carry `if: github.repository != 'rerun-io/lance'` so they skip here instead of hanging.
+`if:` is evaluated before scheduling, so a skipped job never queues.
 
-`rust.yml`, `python.yml` and `java.yml` mostly request lancedb's larger runners
-(`ubuntu-24.04-8x`, `warp-macos-14-arm64-6x`, …), which do not exist in `rerun-io`: such a job sits
-queued for 24 hours and is then cancelled. That is why the Rust and Python runs on `rerun/main` have
-never gone green.
+**Upstream's disabled bit does not travel.** `notebook.yml` is `disabled_manually` upstream, but a
+fork inherits the workflow *file*, not that state — give it a matching branch filter and it wakes up
+and fails (it installs the wheel plus `jupyter` and `duckdb`, while `quickstart.ipynb` also imports
+`pandas`). Before enabling anything here, check upstream first:
 
-`notebook.yml` is `disabled_manually` upstream and broken as written — it installs the wheel plus
-`jupyter` and `duckdb`, but `quickstart.ipynb` also imports `pandas`. A fork inherits the workflow
-file, not the disabled bit, so leave its filter alone or it wakes up red.
+```sh
+gh api repos/lance-format/lance/actions/workflows --jq '.workflows[] | "\(.state)\t\(.path)"'
+```
 
-So **`cargo test`, `clippy` and the Python suite do not run for you here.** Verify them locally and
-say what you ran in the PR body.
+What runs on a PR into a release branch:
+
+| Workflow                   | What it checks                                                     |
+|----------------------------|---------------------------------------------------------------------|
+| `rust.yml`                 | `clippy` (all features, all targets), `cargo-deny`, `cargo fmt`, `rustdoc`, MSRV, and the qemu pre-Haswell SIGILL test |
+| `java.yml`                 | clippy and fmt for `java/lance-jni`                                  |
+| `typos.yml`                | Spelling, whole repo                                                 |
+| `license-header-check.yml` | Apache headers under `rust/`, `python/`, `protos/`                   |
+| `docs-check.yml`           | `docs/` still builds                                                 |
+
+`python.yml` is not enabled: its only standard-runner job is `compat`, which `needs: linux`, and
+`linux` is on a larger runner — so it would produce nothing.
+
+So the lint, advisory and dependency gates do cover you, but **the build-and-test matrix and the
+Python suite do not run here.** Verify those locally and say what you ran in the PR body.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ Guidelines:
 
 ---
 
+## CI on release branches
+
+Upstream scopes its workflows to `main` and `release/**`, which does not match our hyphenated
+`release-X.Y.Z`. Renaming our branches would be the other way to fix that, but downstream pins to
+them by name, so instead these three checks carry an extra `release-*` branch filter and run on PRs
+into a release branch:
+
+| Workflow                   | What it checks                                     |
+|----------------------------|-----------------------------------------------------|
+| `typos.yml`                | Spelling, whole repo                                 |
+| `license-header-check.yml` | Apache headers under `rust/`, `python/`, `protos/`   |
+| `docs-check.yml`           | `docs/` still builds                                 |
+
+Everything else stays off, for two different reasons.
+
+`rust.yml`, `python.yml` and `java.yml` mostly request lancedb's larger runners
+(`ubuntu-24.04-8x`, `warp-macos-14-arm64-6x`, …), which do not exist in `rerun-io`: such a job sits
+queued for 24 hours and is then cancelled. That is why the Rust and Python runs on `rerun/main` have
+never gone green.
+
+`notebook.yml` is `disabled_manually` upstream and broken as written — it installs the wheel plus
+`jupyter` and `duckdb`, but `quickstart.ipynb` also imports `pandas`. A fork inherits the workflow
+file, not the disabled bit, so leave its filter alone or it wakes up red.
+
+So **`cargo test`, `clippy` and the Python suite do not run for you here.** Verify them locally and
+say what you ran in the PR body.
+
+---
+
 ## Cutting a new fork release when upstream releases
 
 When upstream ships a new release `vNEW` (e.g. `v9.0.0`), rebase our patch set onto it.

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1432,16 +1432,25 @@ mod tests {
     fn test_batch_with_undelivered_slot_is_error() {
         let response = Arc::new(Mutex::new(None));
         let response_clone = response.clone();
+        let io_queue = Arc::new(IoQueue::new(2, 0, IoStats::new()));
         let batch = MutableBatch::new(
             move |rsp| *response_clone.lock().unwrap() = Some(rsp),
             2, // num_data_buffers
             0, // priority
             2, // num_reqs
             false,
+            io_queue,
         );
         drop(batch);
 
-        let data = response.lock().unwrap().take().unwrap().data;
+        // `Response` is `Drop` (it refunds backpressure), so take the data out of a
+        // live response rather than moving the field.
+        let mut rsp = response
+            .lock()
+            .unwrap()
+            .take()
+            .expect("batch must deliver a response on drop");
+        let data = rsp.data.take().expect("response must carry data");
         assert!(
             data.is_err(),
             "undelivered slot must yield an error, got {data:?}",


### PR DESCRIPTION
### What

Turns on CI for our branch naming. Upstream filters its workflows on `release/**`, which has never matched our hyphenated `release-X.Y.Z`, so no CI had ever run on a fork release branch.  Skips the jobs that cannot run here due to not having larger runners. Fixes the test the first run caught.

### Testing

Every check on this PR, which is the point of it. The build-and-test matrix and the Python suite still do not run here — they need runner labels this org does not have — so those still require hand verification on a fork PR.

`cargo test -p lance-io --lib scheduler::tests::test_batch_with_undelivered_slot_is_error` also run locally.

### Compatibility

None. No shipped code changes; the only non-CI edit is inside a `#[cfg(test)]` module.

---

🤖 Opened by a coding agent (Claude Opus 5) on Ryan's behalf.
